### PR TITLE
chatgpt: compatible with official response format

### DIFF
--- a/api/chatgpt/chatgpt.go
+++ b/api/chatgpt/chatgpt.go
@@ -151,7 +151,7 @@ func StartConversation(c *gin.Context) {
 	c.Writer.Header().Set("Connection", "keep-alive")
 
 	for eventDataString := range callbackChannel {
-		c.Writer.Write([]byte("data:" + eventDataString + "\n\n"))
+		c.Writer.Write([]byte("data: " + eventDataString + "\n\n"))
 		c.Writer.Flush()
 	}
 }


### PR DESCRIPTION
some api use `data: ` to trim the response data, but here is `data:`, it will make `json.Unmarshal()` reports error: `invalid character 'd' looking for beginning of value`.