### PR TITLE
Allowing fallback routes in chatgpt API

### DIFF
--- a/.github/workflows/docker-push.yaml
+++ b/.github/workflows/docker-push.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          username: linweiyuan
+          username: ${{ github.actor }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Build and push
@@ -30,4 +30,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: linweiyuan/go-chatgpt-api
+          tags: ${{ github.actor }}/go-chatgpt-api

--- a/api/chatgpt/api.go
+++ b/api/chatgpt/api.go
@@ -206,6 +206,34 @@ func Login(c *gin.Context) {
 	c.Writer.WriteString(accessToken)
 }
 
+func Fallback(c *gin.Context) {
+	method := c.Request.Method
+	url := apiPrefix + c.Request.URL.Path
+	queryParams := c.Request.URL.Query().Encode()
+	if queryParams != "" {
+		url += "?" + queryParams
+	}
+
+	var requestBody string
+	if c.Request.Method == http.MethodPost || c.Request.Method == http.MethodPatch {
+		body, _ := io.ReadAll(c.Request.Body)
+		requestBody = string(body)
+	}
+
+	c.Status(http.StatusOK)
+
+	switch method {
+	case http.MethodGet:
+		handleGet(c, url, fallbackErrorMessage)
+	case http.MethodPost:
+		handlePost(c, url, requestBody, fallbackErrorMessage)
+	case http.MethodPatch:
+		handlePatch(c, url, requestBody, fallbackErrorMessage)
+	default:
+		c.JSON(http.StatusMethodNotAllowed, gin.H{"message": fallbackMethodNotAllowedMessage})
+	}
+}
+
 //goland:noinspection GoUnhandledErrorResult
 func handleGet(c *gin.Context, url string, errorMessage string) {
 	req, _ := http.NewRequest(http.MethodGet, url, nil)

--- a/api/chatgpt/constant.go
+++ b/api/chatgpt/constant.go
@@ -1,17 +1,19 @@
 package chatgpt
 
 const (
-	apiPrefix                      = "https://chat.openai.com/backend-api"
-	defaultRole                    = "user"
-	getConversationsErrorMessage   = "Failed to get conversations."
-	generateTitleErrorMessage      = "Failed to generate title."
-	getContentErrorMessage         = "Failed to get content."
-	updateConversationErrorMessage = "Failed to update conversation."
-	clearConversationsErrorMessage = "Failed to clear conversations."
-	feedbackMessageErrorMessage    = "Failed to add feedback."
-	getModelsErrorMessage          = "Failed to get models."
-	getAccountCheckErrorMessage    = "Check failed." // Placeholder. Never encountered.
-	parseJsonErrorMessage          = "Failed to parse json request body."
+	apiPrefix                       = "https://chat.openai.com/backend-api"
+	defaultRole                     = "user"
+	getConversationsErrorMessage    = "Failed to get conversations."
+	generateTitleErrorMessage       = "Failed to generate title."
+	getContentErrorMessage          = "Failed to get content."
+	updateConversationErrorMessage  = "Failed to update conversation."
+	clearConversationsErrorMessage  = "Failed to clear conversations."
+	feedbackMessageErrorMessage     = "Failed to add feedback."
+	getModelsErrorMessage           = "Failed to get models."
+	getAccountCheckErrorMessage     = "Check failed." // Placeholder. Never encountered.
+	parseJsonErrorMessage           = "Failed to parse json request body."
+	fallbackErrorMessage            = "Fallback failed."
+	fallbackMethodNotAllowedMessage = "Fallback method not allowed."
 
 	csrfUrl                  = "https://chat.openai.com/api/auth/csrf"
 	promptLoginUrl           = "https://chat.openai.com/api/auth/signin/auth0?prompt=login"


### PR DESCRIPTION
The current implementation of the ChatGPT API has limited support for various endpoints. For example, the "get plugins" API (backend-api/aip/p) is not currently supported, which can be inconvenient when trying to handle such undefined routes manually.

This pull request aims to improve the ChatGPT API by adding a NoRoute handler to the router. With this enhancement, we can now proxy undefined routes and potentially provide better functionality for these routes.

It also updates the GitHub Action workflow by replacing the hardcoded username `linweiyuan` with the variable ${{ github.actor }}. This modification prevents any errors in actions when used with forked repositories.