### PR TITLE
Support gpt-4-plugins model

### DIFF
--- a/api/chatgpt/api.go
+++ b/api/chatgpt/api.go
@@ -42,7 +42,7 @@ func CreateConversation(c *gin.Context) {
 		request.Messages[0].Author.Role = defaultRole
 	}
 
-	if request.Model == gpt4Model {
+	if request.Model == gpt4Model || request.Model == gpt4BrowsingModel || request.Model == gpt4PluginsModel {
 		formParams := fmt.Sprintf(
 			"public_key=%s",
 			gpt4PublicKey,

--- a/api/chatgpt/constant.go
+++ b/api/chatgpt/constant.go
@@ -20,7 +20,9 @@ const (
 	getCsrfTokenErrorMessage = "Failed to get CSRF token."
 	authSessionUrl           = "https://chat.openai.com/api/auth/session"
 
-	gpt4Model     = "gpt-4"
-	gpt4PublicKey = "35536E1E-65B4-4D96-9D97-6ADB7EFF8147"
-	gpt4TokenUrl  = "https://tcr9i.chat.openai.com/fc/gt2/public_key/" + gpt4PublicKey
+	gpt4Model         = "gpt-4"
+	gpt4BrowsingModel = "gpt-4-browsing"
+	gpt4PluginsModel  = "gpt-4-plugins"
+	gpt4PublicKey     = "35536E1E-65B4-4D96-9D97-6ADB7EFF8147"
+	gpt4TokenUrl      = "https://tcr9i.chat.openai.com/fc/gt2/public_key/" + gpt4PublicKey
 )

--- a/api/chatgpt/typings.go
+++ b/api/chatgpt/typings.go
@@ -13,6 +13,7 @@ type CreateConversationRequest struct {
 	Model             string    `json:"model"`
 	ParentMessageID   string    `json:"parent_message_id"`
 	ConversationID    *string   `json:"conversation_id"`
+	PluginIDs         []string  `json:"plugin_ids"`
 	TimezoneOffsetMin int       `json:"timezone_offset_min"`
 	ArkoseToken       string    `json:"arkose_token"`
 }


### PR DESCRIPTION
The `CreateConversationRequest` struct is currently lacking the `PluginIDs` field. After this modification, we are able to support the GPT-4-plugins model.