### PR TITLE
feat: 增加 pandora 适配

### DIFF
--- a/api/chatgpt/api.go
+++ b/api/chatgpt/api.go
@@ -171,7 +171,7 @@ func handleConversationResponse(c *gin.Context, resp *http.Response, request Cre
 		}
 
 		responseJson := line[6:]
-		if strings.HasPrefix(responseJson, "[DONE]") && isMaxTokens {
+		if strings.HasPrefix(responseJson, "[DONE]") && isMaxTokens && request.AutoContinue {
 			continue
 		}
 

--- a/api/chatgpt/api.go
+++ b/api/chatgpt/api.go
@@ -191,7 +191,7 @@ func handleConversationResponse(c *gin.Context, resp *http.Response, request Cre
 		c.Writer.Flush()
 	}
 
-	if isMaxTokens {
+	if isMaxTokens && request.AutoContinue {
 		var continueConversationRequest = CreateConversationRequest{
 			ArkoseToken:                request.ArkoseToken,
 			HistoryAndTrainingDisabled: request.HistoryAndTrainingDisabled,

--- a/api/chatgpt/typings.go
+++ b/api/chatgpt/typings.go
@@ -17,6 +17,7 @@ type CreateConversationRequest struct {
 	TimezoneOffsetMin          int       `json:"timezone_offset_min"`
 	ArkoseToken                string    `json:"arkose_token"`
 	HistoryAndTrainingDisabled bool      `json:"history_and_training_disabled"`
+	AutoContinue               bool      `json:"auto_continue"`
 }
 
 type Message struct {

--- a/api/common.go
+++ b/api/common.go
@@ -2,6 +2,7 @@ package api
 
 //goland:noinspection GoSnakeCaseUsage
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"math/rand"
@@ -99,7 +100,13 @@ func Proxy(c *gin.Context) {
 	// if not set, will return 404
 	c.Status(http.StatusOK)
 
-	req, _ := http.NewRequest(method, url, nil)
+	var req *http.Request
+	if method == http.MethodGet {
+		req, _ = http.NewRequest(http.MethodGet, url, nil)
+	} else {
+		body, _ := io.ReadAll(c.Request.Body)
+		req, _ = http.NewRequest(method, url, bytes.NewReader(body))
+	}
 	req.Header.Set("User-Agent", UserAgent)
 	req.Header.Set("Authorization", GetAccessToken(c.GetHeader(AuthorizationHeader)))
 	resp, err := Client.Do(req)

--- a/main.go
+++ b/main.go
@@ -26,6 +26,8 @@ func main() {
 	setupChatGPTAPIs(router)
 	setupPlatformAPIs(router)
 
+	router.NoRoute(api.Proxy)
+
 	router.GET("/healthCheck", api.HealthCheck)
 
 	port := os.Getenv("GO_CHATGPT_API_PORT")
@@ -49,7 +51,6 @@ func setupChatGPTAPIs(router *gin.Engine) {
 			conversationGroup.POST("", chatgpt.CreateConversation)
 		}
 	}
-	router.NoRoute(api.Proxy)
 }
 
 func setupPlatformAPIs(router *gin.Engine) {
@@ -63,5 +64,4 @@ func setupPlatformAPIs(router *gin.Engine) {
 			apiGroup.POST("/completions", platform.CreateCompletions)
 		}
 	}
-	router.NoRoute(api.Proxy)
 }


### PR DESCRIPTION
改动点：

1. 占用 `/api/*` 下所有路由并自动重定向到 `/chatgpt/backend-api` 以支持 pandora 的调用。虽然通过 nginx 反代（我有看到 #159 这个问题下的讨论和你的实践，但对我而言并不适用，因为我所有服务跑在 docker compose 的同一个 network 下面，我不想再为此引入 nginx，性价比太低了）
2. 新增 `GO_CHATGPT_API_PANDORA` 这个环境变量用于开启 1. 提到的模式

以及 1. 的实现并不是很优雅，我先尝试了 middleware 的重定向虽然可以通过 `router.HandleContext()` 来重新触发路由匹配，但总是会有其他问题，例如 端点会被处理两次（导致有两个 json），如果使用 `c.Abort()` 则会 pandora 假死等问题，暂时无法很好的解决，也许等我把 gin 的源码读过了能有更好的做法。

BTW，抱歉之前两次手滑开错了 PR :-)