### PR TITLE
feat: push to dockerhub and optional for ghcr

### DIFF
--- a/.github/workflows/docker-push.yaml
+++ b/.github/workflows/docker-push.yaml
@@ -18,6 +18,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -31,3 +39,24 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ github.actor }}/go-chatgpt-api
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
+
+      - name: Log into ghcr
+        uses: docker/login-action@v2
+        if: ${{ vars.USE_GHCR == '1' }}
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push to ghcr
+        uses: docker/build-push-action@v4
+        if: ${{ vars.USE_GHCR == '1' }}
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ github.actor }}/go-chatgpt-api
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max


### PR DESCRIPTION
新增：
- 调整成默认推送到 Dockerhub，可选推送到 GHCR
- workflow 使用 docker layer cache（可以加速打包）

添加 Github actions variables（repo settings-Secrets and variables-actions-repository variables） `USE_GHCR=1`  来控制是否推送