### PR TITLE
feat: workflow_perf

### DIFF
--- a/.github/workflows/docker-push.yaml
+++ b/.github/workflows/docker-push.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - 'main'
 
+env:
+  platforms: ${{ vars.PLATFORMS || 'linux/amd64' }}
+
 jobs:
   docker-build-push:
     runs-on: ubuntu-latest
@@ -36,7 +39,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.platforms }}
           push: true
           tags: ${{ github.actor }}/go-chatgpt-api
           cache-from: type=local,src=/tmp/.buildx-cache
@@ -55,7 +58,7 @@ jobs:
         if: ${{ vars.USE_GHCR == '1' }}
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.platforms }}
           push: true
           tags: ${{ github.actor }}/go-chatgpt-api
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/README.md
+++ b/README.md
@@ -178,6 +178,13 @@ proxy:
   url: https://go-chatgpt-api.linweiyuan.com
 ```
 
+### 如何控制打包行为
+Fork 此项目后，可以在 `Settings-Secrets and variables-Actions` 下控制如下行为：
+`Secrets` 页添加 `DOCKER_HUB_TOKEN` 即可自行打包推送到个人的 Dockerhub 账户下（[如何申请 token](https://docs.docker.com/docker-hub/access-tokens/)）
+
+`Variables` 页添加 `USE_GHCR=1` 即可推送到个人的 GHCR 仓库（[需要开启仓库的写入权限](https://stackoverflow.com/questions/75926611/github-workflow-to-push-docker-image-to-ghcr-io)）
+`Variables` 页添加 `PLATFORMS=linux/amd64,linux/arm64` 即可同时打包 amd64 和 arm64 的架构的镜像（缺省情况下只会打包 amd64）
+
 ---
 
 ### 最后感谢各位同学

--- a/main.go
+++ b/main.go
@@ -87,5 +87,9 @@ func setupPandoraAPIs(router *gin.Engine) {
 			c.Request.URL.Path = strings.ReplaceAll(c.Request.URL.Path, "/api", "/chatgpt/backend-api")
 			router.HandleContext(c)
 		})
+		router.PATCH("/api/*path", func(c *gin.Context) {
+			c.Request.URL.Path = strings.ReplaceAll(c.Request.URL.Path, "/api", "/chatgpt/backend-api")
+			router.HandleContext(c)
+		})
 	}
 }


### PR DESCRIPTION
1. 根据 https://github.com/linweiyuan/go-chatgpt-api/pull/181 的讨论，我们可以只开启 amd64 架构下的打包以加速开发体验，有需要的同学可以根据 README 自行配置交叉编译
2. 同时发现（不确定之前是不是我漏了还是有更新）pandora 的会话删除是通过 PATCH 操作的，因此需要 pandora 的兼容 API 端点也需要同时支持 PATCH 方法