### PR TITLE
Update Authorization Header Retrieval Method

### DIFF
--- a/api/chatgpt/api.go
+++ b/api/chatgpt/api.go
@@ -75,7 +75,7 @@ func sendConversationRequest(c *gin.Context, request CreateConversationRequest) 
 	jsonBytes, _ := json.Marshal(request)
 	req, _ := http.NewRequest(http.MethodPost, api.ChatGPTApiUrlPrefix+"/backend-api/conversation", bytes.NewBuffer(jsonBytes))
 	req.Header.Set("User-Agent", api.UserAgent)
-	req.Header.Set("Authorization", api.GetAccessToken(c.GetHeader(api.AuthorizationHeader)))
+	req.Header.Set("Authorization", api.GetAccessTokenFromHeader(c.Request.Header))
 	req.Header.Set("Accept", "text/event-stream")
 	if puid != "" {
 		//goland:noinspection SpellCheckingInspection
@@ -92,7 +92,7 @@ func sendConversationRequest(c *gin.Context, request CreateConversationRequest) 
 
 		req, _ := http.NewRequest(http.MethodGet, api.ChatGPTApiUrlPrefix+"/backend-api/models?history_and_training_disabled=false", nil)
 		req.Header.Set("User-Agent", api.UserAgent)
-		req.Header.Set("Authorization", api.GetAccessToken(c.GetHeader(api.AuthorizationHeader)))
+		req.Header.Set("Authorization", api.GetAccessTokenFromHeader(c.Request.Header))
 		response, err := api.Client.Do(req)
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusInternalServerError, api.ReturnMessage(err.Error()))

--- a/api/common.go
+++ b/api/common.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	nethttp "net/http"
 	"os"
 	"strings"
 
@@ -57,6 +58,7 @@ type AuthLogin interface {
 	CheckUsername(state string, username string) (int, error)
 	CheckPassword(state string, username string, password string) (string, int, error)
 	GetAccessToken(code string) (string, int, error)
+	GetAccessTokenFromHeader(c *gin.Context) (string, int, error)
 }
 
 //goland:noinspection GoUnhandledErrorResult
@@ -143,4 +145,15 @@ func GetAccessToken(accessToken string) string {
 		return "Bearer " + accessToken
 	}
 	return accessToken
+}
+
+func GetAccessTokenFromHeader(header nethttp.Header) string {
+	// pandora will pass X-Authorization header
+	// but maybe other project will use Authorization header to pass access token
+	xAuth := header.Get("X-Authorization")
+	if xAuth == "" {
+		return GetAccessToken(header.Get(AuthorizationHeader))
+	} else {
+		return GetAccessToken(xAuth)
+	}
 }

--- a/api/platform/api.go
+++ b/api/platform/api.go
@@ -74,7 +74,7 @@ func handleCompletionsResponse(c *gin.Context, resp *http.Response) {
 
 func handlePost(c *gin.Context, url string, data []byte, stream bool) (*http.Response, error) {
 	req, _ := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(data))
-	req.Header.Set("Authorization", api.GetAccessToken(c.GetHeader(api.AuthorizationHeader)))
+	req.Header.Set("Authorization", api.GetAccessTokenFromHeader(c.Request.Header))
 	if stream {
 		req.Header.Set("Accept", "text/event-stream")
 	}


### PR DESCRIPTION
- Updated the method of retrieving the Authorization header in chatgpt/api.go and platform/api.go.
- Introduced a new function, GetAccessTokenFromHeader, in common.go to fetch the access token from either the Authorization or X-Authorization header.
- This change provides flexibility to handle different projects that may use different headers for passing access tokens.