### PR TITLE
Refactor Authorization Header Retrieval in Proxy Function

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -114,7 +114,7 @@ func Proxy(c *gin.Context) {
 		req, _ = http.NewRequest(method, url, bytes.NewReader(body))
 	}
 	req.Header.Set("User-Agent", UserAgent)
-	req.Header.Set("Authorization", GetAccessToken(c.GetHeader(AuthorizationHeader)))
+	req.Header.Set("Authorization", GetAccessTokenFromHeader(c.Request.Header))
 	resp, err := Client.Do(req)
 	if err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, ReturnMessage(err.Error()))


### PR DESCRIPTION
- Updated the Proxy function in common.go to use the GetAccessTokenFromHeader method for setting the Authorization header.
- This change aligns the Proxy function with the updated method of retrieving the access token from either the Authorization or X-Authorization header.