### PR TITLE
support multimodal_text content and attachments

### DIFF
--- a/api/chatgpt/typings.go
+++ b/api/chatgpt/typings.go
@@ -27,14 +27,15 @@ func (c *CreateConversationRequest) AddMessage(role string, content string) {
 	c.Messages = append(c.Messages, Message{
 		ID:      uuid.New().String(),
 		Author:  Author{Role: role},
-		Content: Content{ContentType: "text", Parts: []string{content}},
+		Content: Content{ContentType: "text", Parts: []interface{}{content}},
 	})
 }
 
 type Message struct {
-	Author  Author  `json:"author"`
-	Content Content `json:"content"`
-	ID      string  `json:"id"`
+	Author   Author      `json:"author"`
+	Content  Content     `json:"content"`
+	ID       string      `json:"id"`
+	Metadata interface{} `json:"metadata"`
 }
 
 type Author struct {
@@ -42,8 +43,8 @@ type Author struct {
 }
 
 type Content struct {
-	ContentType string   `json:"content_type"`
-	Parts       []string `json:"parts"`
+	ContentType string        `json:"content_type"`
+	Parts       []interface{} `json:"parts"`
 }
 
 type CreateConversationResponse struct {

--- a/api/imitate/convert.go
+++ b/api/imitate/convert.go
@@ -1,15 +1,36 @@
 package imitate
 
 import (
+	"fmt"
 	"strings"
 )
 
 func ConvertToString(chatgptResponse *ChatGPTResponse, previousText *StringStruct, role bool, id string, model string) string {
-	text := strings.ReplaceAll(chatgptResponse.Message.Content.Parts[0], *&previousText.Text, "")
+	var text string
+
+	if len(chatgptResponse.Message.Content.Parts) == 1 {
+		if part, ok := chatgptResponse.Message.Content.Parts[0].(string); ok {
+			text = strings.ReplaceAll(part, previousText.Text, "")
+			previousText.Text = part
+		} else {
+			text = fmt.Sprintf("%v", chatgptResponse.Message.Content.Parts[0])
+		}
+	} else {
+		// When using GPT-4 messages with images (multimodal_text), the length of 'parts' might be 2.
+		// Since the chatgpt API currently does not support multimodal content
+		// and there is no official format for multimodal content,
+		// the content is temporarily returned as is.
+		var parts []string
+		for _, part := range chatgptResponse.Message.Content.Parts {
+			parts = append(parts, fmt.Sprintf("%v", part))
+		}
+		text = strings.Join(parts, ", ")
+	}
+
 	translatedResponse := NewChatCompletionChunk(text, id, model)
 	if role {
 		translatedResponse.Choices[0].Delta.Role = chatgptResponse.Message.Author.Role
 	}
-	previousText.Text = chatgptResponse.Message.Content.Parts[0]
+
 	return "data: " + translatedResponse.String() + "\n\n"
 }


### PR DESCRIPTION
GPT-4 现在支持多模态内容，图片格式类似于：

```json
{
  "action": "next",
  "messages": [
    {
      "id": "",
      "author": {
        "role": "user"
      },
      "content": {
        "content_type": "multimodal_text",
        "parts": [
          {
            "asset_pointer": "file-service://file-xxxxxxxxx",
            "size_bytes": 19599,
            "width": 868,
            "height": 56
          },
          "图片内容是什么？"
        ]
      },
      "metadata": {}
    }
  ],
  "model": "gpt-4"
}
```

此外，在 gpt-4-code-interpreter 模型中上传附件也需要 metadata 中的 attachments 字段。